### PR TITLE
Update default Stripe minimum to $0.50

### DIFF
--- a/charj/cards/tests.py
+++ b/charj/cards/tests.py
@@ -88,6 +88,19 @@ class TestAddCardView:
         assert response.status_code == HTTPStatus.FOUND
         assert "/accounts/login/" in response.url
 
+    def test_default_minimum_is_fifty_cents(self, user: User, rf: RequestFactory):
+        """The page context should advertise the $0.50 minimum by default.
+
+        Marketing promises a $0.50 minimum, so the default config (no
+        STRIPE_MIN_AMOUNT_CENTS override) must propagate 50 cents to the
+        frontend pricing config and the displayed minimum.
+        """
+        request = rf.get("/fake-url/")
+        request.user = user
+        response = add_card_view(request)
+        assert response.context_data["pricing_config"]["minAmountCents"] == 50  # noqa: PLR2004
+        assert response.context_data["min_amount_dollars"] == 0.50  # noqa: PLR2004
+
 
 class TestCreateSetupIntentView:
     """Tests for the SetupIntent creation API endpoint."""
@@ -416,6 +429,16 @@ class TestPricingServiceValidation:
     def test_validate_pricing_parameters_amount_too_low(self, settings):
         """Amount below minimum should raise error."""
         settings.STRIPE_MIN_AMOUNT_CENTS = 50
+        with pytest.raises(InvalidPricingParametersError) as exc_info:
+            validate_pricing_parameters(49, "year", 1)
+        assert "at least 50 cents" in str(exc_info.value)
+
+    def test_default_minimum_accepts_fifty_cents(self):
+        """The default config (no override) must accept the advertised $0.50."""
+        validate_pricing_parameters(50, "year", 1)
+
+    def test_default_minimum_rejects_below_fifty_cents(self):
+        """The default config (no override) must reject amounts below $0.50."""
         with pytest.raises(InvalidPricingParametersError) as exc_info:
             validate_pricing_parameters(49, "year", 1)
         assert "at least 50 cents" in str(exc_info.value)

--- a/charj/templates/cards/add_card.html
+++ b/charj/templates/cards/add_card.html
@@ -75,7 +75,7 @@
                     <input type="number"
                            class="form-control"
                            id="custom-amount"
-                           min="0.50"
+                           min="{{ min_amount_dollars }}"
                            max="1000"
                            step="0.01"
                            value="1.00"
@@ -102,7 +102,7 @@
                 </div>
               </div>
               <div class="small text-muted">
-                Min: ${{ min_amount_dollars }} | Max: $1,000 | Intervals: 1-{{ max_interval_count }}
+                Min: ${{ min_amount_dollars|floatformat:2 }} | Max: $1,000 | Intervals: 1-{{ max_interval_count }}
               </div>
             </div>
             <!-- Dynamic Pricing Summary -->

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -338,8 +338,8 @@ STRIPE_PRODUCT_ID = env("STRIPE_PRODUCT_ID", default="")
 # Custom Pricing Constraints
 STRIPE_MIN_AMOUNT_CENTS = env.int(
     "STRIPE_MIN_AMOUNT_CENTS",
-    default=100,
-)  # $1.00 minimum
+    default=50,
+)  # $0.50 minimum (Stripe's USD minimum)
 STRIPE_MAX_AMOUNT_CENTS = env.int(
     "STRIPE_MAX_AMOUNT_CENTS",
     default=100000,


### PR DESCRIPTION
## Summary
Updates the default minimum charge amount from $1.00 to $0.50 to align with Stripe's USD minimum and match marketing promises.

## Key Changes
- Changed `STRIPE_MIN_AMOUNT_CENTS` default from 100 to 50 in settings
- Updated HTML template to use dynamic `min_amount_dollars` variable instead of hardcoded "0.50"
- Added `floatformat:2` filter to ensure consistent decimal formatting in the pricing summary display
- Added test coverage for the new default minimum:
  - `test_default_minimum_is_fifty_cents`: Verifies the add card view context includes the correct minimum
  - `test_default_minimum_accepts_fifty_cents`: Confirms validation accepts $0.50
  - `test_default_minimum_rejects_below_fifty_cents`: Confirms validation rejects amounts below $0.50

## Implementation Details
The changes ensure that the frontend and backend are synchronized on the minimum charge amount. The template now dynamically renders the minimum from the view context rather than hardcoding it, making the system more maintainable if the minimum is overridden via environment variables.

https://claude.ai/code/session_01KMTL3a5vg6tW8V9L5WZ54t