### PR TITLE
Document Claude Code sandbox setup and fix AGENTS.md drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,14 @@ inactivity.
 
 This project uses `uv` for dependency management. Virtual environment is at `.venv/`.
 
+> **Claude Code on the web / fresh sandbox?** Start with
+> [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md). It covers the hurdles a
+> fresh, network-restricted container hits before any command below works:
+> missing `libpq-dev` (psycopg-c build failure), bootstrapping PostgreSQL,
+> creating a login-capable test user, the Stripe API call on login that
+> 500s without network access, and stubbing blocked CDN scripts for
+> browser-based verification.
+
 ### Running the Development Server
 
 ```bash
@@ -184,16 +192,23 @@ Uses a custom User model (`charj.users.User`) with email-based authentication in
 
 Main URL configuration in `config/urls.py`:
 - `/` - Home page
+- `/pricing/` - Pricing page
 - `/about/` - About page
 - `/admin/` - Django admin
 - `/users/` - User management URLs
 - `/accounts/` - django-allauth authentication URLs
+- `/cards/` - Card dashboard and add-card flow (`charj.cards`):
+  - `/cards/` - Dashboard listing cards and subscriptions
+  - `/cards/add/` - Add card flow (Stripe Elements + SetupIntent)
+  - `/cards/customer-portal/` - Redirect to Stripe Customer Portal
 - `/djstripe/` - dj-stripe dashboard
 
 ### Django Apps
 
 Local apps are in the `charj/` directory:
 - `charj.users` - Custom user model and authentication
+- `charj.cards` - Core business logic: card dashboard, add-card flow,
+  subscription creation, and the dynamic pricing service
 - `charj.contrib.sites` - Custom sites migration module
 
 ### Templates
@@ -219,10 +234,21 @@ Key environment variables (configured in `.env` file):
 - `DJANGO_READ_DOT_ENV_FILE` - Set to `True` to read `.env` file
 - `STRIPE_TEST_SECRET_KEY` - Stripe test secret key
 - `STRIPE_TEST_PUBLIC_KEY` - Stripe test public key
+- `STRIPE_PRICE_ID` / `STRIPE_PRODUCT_ID` - Stripe product/price for dynamic pricing
+- `STRIPE_MIN_AMOUNT_CENTS` - Minimum charge amount (defaults to `50`, i.e. $0.50 —
+  the minimum promised on the marketing pages and Stripe's USD minimum)
+- `STRIPE_MAX_AMOUNT_CENTS` - Maximum charge amount (defaults to `100000`, i.e. $1,000)
+- `STRIPE_MAX_INTERVAL_COUNT` - Maximum billing interval count (defaults to `36`)
 - `REDIS_URL` - Redis connection string (defaults to `redis://localhost:6379/0`)
 - `DJANGO_SECRET_KEY` - Django secret key (has default for local dev)
 - `DJANGO_DEBUG` - Debug mode flag
 - `DJANGO_ACCOUNT_ALLOW_REGISTRATION` - Allow user registration
+
+**Deployment caveat:** the pricing constraints above are env-overridable.
+A stale `STRIPE_MIN_AMOUNT_CENTS` set on the production host silently
+overrides the code default — check host config vars when changing pricing
+limits, and keep them consistent with the marketing copy in
+`charj/templates/pages/home.html` and `pricing.html`.
 
 ## Email in Development
 
@@ -277,6 +303,18 @@ This approach ensures visual consistency across all pages and makes the design s
 
 The `charj/users/signals.py` file contains critical Stripe customer creation logic that runs on user login. When modifying user authentication flow, ensure this signal continues to work correctly.
 
+### Dynamic Pricing Service
+
+`charj/cards/pricing_service.py` resolves a Stripe Price for any
+(amount, interval, interval_count) combination via a three-tier lookup:
+local djstripe cache first, then a Stripe API search by `lookup_key`
+(format: `{interval}_{interval_count}_{amount_cents}`), then dynamic
+creation under `STRIPE_PRODUCT_ID`. All amount/interval validation lives
+in `validate_pricing_parameters()` — both the backend subscription flow
+and the frontend config served by `AddCardView` read the same
+`STRIPE_*` settings, so constraint changes belong in settings, not in
+templates or views.
+
 ### Settings Pattern
 
 Environment-specific settings import from base: `from .base import *`. Always add new shared settings to `base.py` and override only what's needed in environment files.
@@ -294,3 +332,13 @@ Tests use:
 - Coverage plugin: django_coverage_plugin
 - Test files: `tests.py` or `test_*.py`
 - Factory Boy for test fixtures
+
+### Testing Convention: Defaults vs Overrides
+
+A test that sets `settings.SOME_SETTING = X` only proves behavior *at X* —
+it cannot catch a wrong default in `base.py`. Values the product promises
+externally (e.g. the $0.50 minimum advertised on the marketing pages) must
+have at least one test that exercises the **unmodified default settings**.
+See `test_default_minimum_accepts_fifty_cents` in `charj/cards/tests.py`
+for the pattern; this exists because every minimum-amount test once
+overrode the setting and a $1.00 default shipped unnoticed.

--- a/CLAUDE_CODE_SETUP.md
+++ b/CLAUDE_CODE_SETUP.md
@@ -1,0 +1,111 @@
+# Claude Code / Sandbox Environment Setup
+
+Setup guide for Claude Code on the web and other fresh, network-restricted
+sandbox environments. Every hurdle documented here was hit in a real agent
+session — follow this file top to bottom and `uv run pytest` and the dev
+server will work on a fresh clone.
+
+## 1. System prerequisites
+
+`psycopg-c` is compiled from source during `uv sync` and fails with
+`pg_config.h: No such file or directory` unless the PostgreSQL client
+headers are installed:
+
+```bash
+sudo apt-get install -y libpq-dev
+```
+
+## 2. PostgreSQL
+
+The default `DATABASE_URL` is `postgres:///charj` (peer-authenticated local
+socket). A fresh container has the cluster stopped and no role or database:
+
+```bash
+pg_ctlcluster 16 main start    # adjust version; or: service postgresql start
+sudo -u postgres psql -c "CREATE ROLE \"$(whoami)\" SUPERUSER LOGIN;"
+sudo -u postgres createdb charj -O "$(whoami)"
+```
+
+Then:
+
+```bash
+uv sync
+uv run python manage.py migrate
+```
+
+`uv run pytest` works from this point (tests use `config.settings.test`
+with `--reuse-db`).
+
+## 3. Creating a user you can actually log in with
+
+Email verification is mandatory (`ACCOUNT_EMAIL_VERIFICATION = "mandatory"`),
+so a user created with `createsuperuser` cannot log in through the UI until
+a verified allauth `EmailAddress` exists. Create a ready-to-use account
+non-interactively:
+
+```bash
+uv run python manage.py shell -c "
+from django.contrib.auth import get_user_model
+from allauth.account.models import EmailAddress
+U = get_user_model()
+u, _ = U.objects.get_or_create(email='dev@example.com', defaults={'name': 'Dev'})
+u.set_password('dev-pass-123'); u.is_active = True; u.save()
+EmailAddress.objects.update_or_create(user=u, email=u.email,
+    defaults={'verified': True, 'primary': True})
+"
+```
+
+## 4. Login calls the Stripe API — pre-seed a Customer
+
+The `user_logged_in` signal (`charj/users/signals.py`) calls
+`Customer.get_or_create()`, which makes a **live HTTPS request to
+api.stripe.com**. In a sandbox with no network access (or with the dummy
+`sk_test_12345` key), **every login returns a 500**.
+
+Workaround: seed a djstripe `Customer` for your test user so the signal's
+queryset is non-empty and it never reaches the API:
+
+```bash
+uv run python manage.py shell -c "
+from django.contrib.auth import get_user_model
+from djstripe.models import Customer
+u = get_user_model().objects.get(email='dev@example.com')
+Customer.objects.get_or_create(id='cus_local_dev',
+    defaults={'email': u.email, 'subscriber': u, 'livemode': False})
+"
+```
+
+## 5. Frontend pages depend on external CDNs
+
+Templates load scripts from `js.stripe.com`, `cdnjs.cloudflare.com`
+(Bootstrap), `googletagmanager.com`, and `m.charj.cc`. Restricted network
+policies block these, and on the Add Card page the failure is total: the
+inline script calls `Stripe(...)` before attaching any event listeners, so
+`Stripe is not defined` aborts the script and **the page renders but nothing
+responds** (preset buttons, custom amount, summary).
+
+For browser-based verification (Playwright), stub the Stripe script so the
+page's own code runs unmodified:
+
+```js
+await page.route('https://js.stripe.com/v3/', route => route.fulfill({
+  contentType: 'application/javascript',
+  body: `window.Stripe = function () { return {
+    elements: () => ({ create: () => ({ mount: () => {}, addEventListener: () => {} }) }),
+    confirmCardSetup: () => Promise.resolve({})
+  }; };`,
+}));
+```
+
+The other blocked scripts (analytics, Bootstrap JS) only log console errors
+and don't break the pricing flow.
+
+## 6. Things that hit the Stripe API and cannot work offline
+
+No workaround exists for these in a sandbox — verify them with unit tests
+(which mock Stripe) rather than live:
+
+- Creating a subscription (`/cards/create-subscription/`) — attaches the
+  payment method and creates prices/subscriptions in Stripe.
+- The Customer Portal redirect (`/cards/customer-portal/`).
+- `stripe.confirmCardSetup()` in the browser.


### PR DESCRIPTION
## Summary

Follow-up to #47. While fixing the $0.50 minimum, a fresh sandbox session hit several undocumented setup hurdles. This PR captures them so the next agent (or contributor) doesn't rediscover each one.

### New: `CLAUDE_CODE_SETUP.md`

A dedicated guide for Claude Code on the web and other fresh, network-restricted environments:

- `psycopg-c` build failure without `libpq-dev`
- Bootstrapping PostgreSQL for the `postgres:///charj` default (cluster start, role, database)
- Creating a login-capable test user despite mandatory email verification
- The `user_logged_in` signal makes a live Stripe API call — login 500s offline unless a djstripe `Customer` is pre-seeded
- Frontend pages load scripts from external CDNs; on the Add Card page a blocked `js.stripe.com` aborts the inline script entirely — includes a Playwright stub for browser verification
- Which flows can never work offline and should be verified via mocked tests instead

### AGENTS.md updates

- Point to `CLAUDE_CODE_SETUP.md` from Development Setup for web/sandbox sessions
- Fix drift: add `charj.cards` to the app list, `/cards/` routes and `/pricing/` to the URL structure
- Document the pricing service's three-tier price lookup pattern
- List the `STRIPE_MIN_AMOUNT_CENTS` / `STRIPE_MAX_AMOUNT_CENTS` / `STRIPE_MAX_INTERVAL_COUNT` env vars with defaults, plus a deployment caveat about stale host overrides silently winning over code defaults
- Record the defaults-vs-overrides testing convention: tests that override a setting can't catch a wrong default — externally promised values need at least one test against unmodified defaults (the exact gap that let the $1.00 default ship)

https://claude.ai/code/session_01KMTL3a5vg6tW8V9L5WZ54t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTL3a5vg6tW8V9L5WZ54t)_