### PR TITLE
Send a personal feedback email to users from the admin

### DIFF
--- a/charj/templates/emails/feedback_request.txt
+++ b/charj/templates/emails/feedback_request.txt
@@ -1,0 +1,20 @@
+{% comment %}
+"Im" below is a deliberate typo, it makes the note read as hand-typed.
+{% endcomment %}{% autoescape off %}Hi {{ user.name|default:"there" }},
+
+I'm Abe, I built Charj. I saw you added a card, thanks for that, it
+made my day.
+
+If you've got thirty seconds: where did you hear about Charj? Google,
+reddit, a friend? Im trying to work out what's actually reaching
+people, and right now I'm mostly guessing.
+
+And if anything felt clunky or broken while you were setting it up,
+tell me. I'd rather hear it now than never.
+
+Just hit reply, it comes straight to me.
+
+Thanks,
+Abe
+charj.cc
+{% endautoescape %}

--- a/charj/users/admin.py
+++ b/charj/users/admin.py
@@ -1,12 +1,18 @@
+import logging
+
 from allauth.account.decorators import secure_admin_login
 from django.conf import settings
 from django.contrib import admin
+from django.contrib import messages
 from django.contrib.auth import admin as auth_admin
 from django.utils.translation import gettext_lazy as _
 
+from .emails import send_feedback_email
 from .forms import UserAdminChangeForm
 from .forms import UserAdminCreationForm
 from .models import User
+
+logger = logging.getLogger(__name__)
 
 if settings.DJANGO_ADMIN_FORCE_ALLAUTH:
     # Force the `admin` sign in process to go through the `django-allauth` workflow:
@@ -44,6 +50,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "last_login",
     ]
     search_fields = ["name", "email"]
+    actions = ["send_feedback_email_action"]
 
     ordering = ["-last_login"]
     add_fieldsets = (
@@ -55,3 +62,21 @@ class UserAdmin(auth_admin.UserAdmin):
             },
         ),
     )
+
+    @admin.action(description="Send welcome / feedback email", permissions=["change"])
+    def send_feedback_email_action(self, request, queryset):
+        """Send immediately: no confirmation step, so report who was mailed."""
+        sent, failed = [], []
+        for user in queryset:
+            try:
+                send_feedback_email(user)
+            except Exception:
+                logger.exception("Feedback email failed for %s", user.pk)
+                failed.append(user.email)
+            else:
+                sent.append(user.email)
+
+        if sent:
+            self.message_user(request, f"Sent to: {', '.join(sent)}", messages.SUCCESS)
+        if failed:
+            self.message_user(request, f"FAILED: {', '.join(failed)}", messages.ERROR)

--- a/charj/users/emails.py
+++ b/charj/users/emails.py
@@ -1,0 +1,25 @@
+"""Outbound application email for the users app."""
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
+
+from .models import User
+
+SUBJECT = "where'd you hear about Charj?"
+BODY_TEMPLATE = "emails/feedback_request.txt"
+
+
+def render_feedback_body(user: User) -> str:
+    """Return the plain-text body of the feedback email to ``user``."""
+    return render_to_string(BODY_TEMPLATE, {"user": user})
+
+
+def send_feedback_email(user: User) -> None:
+    """Send to one user only: a shared to/cc list would leak addresses."""
+    EmailMessage(
+        subject=SUBJECT,
+        body=render_feedback_body(user),
+        from_email=settings.FEEDBACK_FROM_EMAIL,
+        to=[user.email],
+    ).send()

--- a/charj/users/tests/test_admin.py
+++ b/charj/users/tests/test_admin.py
@@ -1,6 +1,7 @@
 import contextlib
 from http import HTTPStatus
 from importlib import reload
+from typing import cast
 
 import pytest
 from django.contrib import admin
@@ -9,6 +10,7 @@ from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
 from charj.users.models import User
+from charj.users.tests.factories import UserFactory
 
 
 class TestUserAdmin:
@@ -63,3 +65,27 @@ class TestUserAdmin:
         # The `admin` login view should redirect to the `allauth` login view
         target_url = reverse(settings.LOGIN_URL) + "?next=" + request.path
         assertRedirects(response, target_url, fetch_redirect_response=False)
+
+
+class TestSendFeedbackEmailAction:
+    def test_sends_a_separate_message_to_each_user(self, admin_client, mailoutbox):
+        """A shared to/cc list would expose every user's address to the others."""
+        users = [cast("User", UserFactory()) for _ in range(3)]
+        admin_client.post(
+            reverse("admin:users_user_changelist"),
+            data={
+                "action": "send_feedback_email_action",
+                "_selected_action": [str(u.pk) for u in users],
+            },
+        )
+        # Set comparison: the changelist orders by -last_login, not creation.
+        assert [len(m.to) for m in mailoutbox] == [1, 1, 1]
+        assert {m.to[0] for m in mailoutbox} == {u.email for u in users}
+
+    @pytest.mark.django_db
+    def test_hidden_from_staff_without_change_permission(self, rf):
+        """View-only staff must not be able to mass-email the customer base."""
+        request = rf.get("/")
+        request.user = cast("User", UserFactory(is_staff=True))
+        actions = admin.site._registry[User].get_actions(request)  # noqa: SLF001
+        assert "send_feedback_email_action" not in actions

--- a/charj/users/tests/test_emails.py
+++ b/charj/users/tests/test_emails.py
@@ -1,0 +1,63 @@
+import pytest
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+
+from charj.users.emails import render_feedback_body
+from charj.users.emails import send_feedback_email
+from charj.users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+class TestRenderFeedbackBody:
+    def test_greets_user_by_name(self, user: User):
+        user.name = "Dana Scully"
+        assert render_feedback_body(user).startswith("Hi Dana Scully,")
+
+    def test_blank_name_falls_back_to_there(self, user: User):
+        user.name = ""
+        assert render_feedback_body(user).startswith("Hi there,")
+
+    def test_name_is_not_html_escaped(self, user: User):
+        """The body is plain text, so an apostrophe must survive verbatim."""
+        user.name = "Seamus O'Brien"
+        assert "Seamus O'Brien" in render_feedback_body(user)
+
+    def test_asks_where_they_heard_not_how_they_found(self, user: User):
+        """ "How did you find it" reads to many people as "what did you think"."""
+        body = render_feedback_body(user)
+        assert "where did you hear about Charj?" in body
+        assert "how did you find" not in body.lower()
+
+    def test_contains_no_em_dash(self, user: User):
+        assert "\u2014" not in render_feedback_body(user)
+
+    def test_does_not_disclose_user_counts(self, user: User):
+        """Calling someone an early user tells them how few users there are."""
+        lowered = render_feedback_body(user).lower()
+        assert "first" not in lowered
+        assert "one of the" not in lowered
+
+
+class TestSendFeedbackEmail:
+    def test_sends_to_the_user(self, user: User, mailoutbox):
+        send_feedback_email(user)
+        assert len(mailoutbox) == 1
+        assert mailoutbox[0].to == [user.email]
+
+    def test_replies_reach_a_person(self, user: User, mailoutbox):
+        """The body promises a reply reaches a person, so From must not bounce.
+
+        No Reply-To is set: absent one, replies go to From, which is already a
+        real inbox.
+        """
+        send_feedback_email(user)
+        assert mailoutbox[0].from_email == settings.FEEDBACK_FROM_EMAIL
+        assert "noreply" not in mailoutbox[0].from_email
+        assert mailoutbox[0].reply_to == []
+
+    def test_is_plain_text_only(self, user: User, mailoutbox):
+        """No HTML part at all: a designed email stops reading as a personal note."""
+        send_feedback_email(user)
+        assert not isinstance(mailoutbox[0], EmailMultiAlternatives)
+        assert not mailoutbox[0].message().is_multipart()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -242,6 +242,12 @@ EMAIL_BACKEND = env(
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-timeout
 EMAIL_TIMEOUT = 5
+# The feedback email is signed by a person and asks for a reply, so it is sent
+# from a real inbox rather than the `noreply@` default.
+FEEDBACK_FROM_EMAIL = env(
+    "DJANGO_FEEDBACK_FROM_EMAIL",
+    default="Abe Hanoka <abe@charj.cc>",
+)
 
 # ADMIN
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a short plain-text email asking a user where they heard about Charj, and an admin action to send it.

Charj has real users now and nothing that answers where they came from. Rather than build tracking, this asks them.

### Commits

- **Add the feedback request email** — template, send helper, one setting. Nothing calls it.
- **Send the feedback email from the user admin** — the changelist action that calls it.

### Using it

Admin → Users → select → "Send welcome / feedback email". Sends immediately with no confirmation page, so the success message names each recipient rather than counting them.

### Notes

- Plain text, no HTML part: a designed email stops reading as a personal note. The copy is deliberately unpolished, including one intentional typo, which is documented in the template so it survives a cleanup pass.
- Sent from `abe@charj.cc`, not `noreply@`, because the body asks for a reply. No `Reply-To` header: absent one, replies go to `From`, which is already the right inbox. One new setting, `FEEDBACK_FROM_EMAIL`, overridable with `DJANGO_FEEDBACK_FROM_EMAIL`.
- One message per recipient, never a shared to/cc list, so no user can see another's address. Covered by a test.
- Gated on the `change` permission so view-only staff cannot mass-mail the user base. Covered by a test.
- The wording was worked through in review, so the copy decisions are pinned by tests: no em dash, nothing that discloses how few users there are, and "where did you hear about Charj" rather than "how did you find it" (which reads as "what did you think of it").
- Manual by design: there is no task queue in this project, and at this volume picking the moment by hand beats a scheduler.

### Before merging

`abe@charj.cc` needs to actually receive mail, and Mailjet needs to be authorized for the `charj.cc` sender domain. A reply that bounces makes the email worse than not sending it.

### Verification

`uv run pytest` (91 passing), `pre-commit run --all-files`, and `makemigrations --check` all clean. No migrations. Both commits verified green independently, not just the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPhS7jdAZmPvVDTkSCZu1Q